### PR TITLE
Fixed macOS build

### DIFF
--- a/Sources/Controls/Control.swift
+++ b/Sources/Controls/Control.swift
@@ -69,7 +69,7 @@ public struct Control<Content: View>: View {
             .onAppear {
                 rect = proxy.frame(in: .local)
             }
-            .onChange(of: proxy.size) {
+            .onChange(of: proxy.size) { _ in
                 rect = proxy.frame(in: .local)
             }
         }

--- a/Sources/Controls/Implementations/IndexedSlider.swift
+++ b/Sources/Controls/Implementations/IndexedSlider.swift
@@ -40,7 +40,8 @@ public struct IndexedSlider: View {
                 .offset(x: CGFloat(index) * geo.size.width / CGFloat(labels.count))
                 .animation(.easeOut, value: index)
             }
-        }.onChange(of: normalValue) {
+        }
+        .onChange(of: normalValue) { _ in
             index = Int(normalValue * 0.99 * Float(labels.count))
         }
     }

--- a/Sources/Controls/TwoParameterControl.swift
+++ b/Sources/Controls/TwoParameterControl.swift
@@ -77,7 +77,7 @@ public struct TwoParameterControl<Content: View>: View {
             .onAppear {
                 rect = proxy.frame(in: .local)
             }
-            .onChange(of: proxy.size) {
+            .onChange(of: proxy.size) { _ in
                 rect = proxy.frame(in: .local)
             }
         }


### PR DESCRIPTION
Compiler will throw warnings about deprecated API on visionOS but this is the simplest fix to get all platforms to compile at the moment.